### PR TITLE
Events

### DIFF
--- a/lib/Maki.js
+++ b/lib/Maki.js
@@ -4,6 +4,7 @@ if (process.env.NODE_ENV === 'debug') require('debug-trace')({ always: true });
 
 var _ = require('lodash');
 var colors = require('colors');
+var util = require('util');
 
 var Maki = function( config ) {
   var defaults = require( __dirname + '/../config');
@@ -32,6 +33,8 @@ var Maki = function( config ) {
 
   this.register('http', require('../lib/Service/http') );
 };
+
+util.inherits( Maki , require('events').EventEmitter );
 
 Maki.prototype.define = function( name , options ) {
   var self = this;

--- a/lib/Maki.js
+++ b/lib/Maki.js
@@ -5,6 +5,7 @@ if (process.env.NODE_ENV === 'debug') require('debug-trace')({ always: true });
 var _ = require('lodash');
 var colors = require('colors');
 var util = require('util');
+var async = require('async');
 
 var Maki = function( config ) {
   var defaults = require( __dirname + '/../config');
@@ -43,6 +44,7 @@ Maki.prototype.define = function( name , options ) {
   var resource = new self.Resource( name , options );
 
   resource.attach( self );
+  self.emit('resource', resource );
 
   return resource;
 };
@@ -72,7 +74,7 @@ Maki.prototype.register = function( name , service ) {
   return this;
 };
 
-Maki.prototype.serve = function( services ) {
+Maki.prototype.serve = function( services , cb ) {
   var self = this;
   if (typeof services === 'String') var services = [ services ];
 
@@ -94,7 +96,7 @@ Maki.prototype.serve = function( services ) {
     });
   }
 
-  services.forEach(function( name ) {
+  async.each( services , function( name , complete ) {
     var Service = self._services[ name ];
     self.services[ name ] = new Service();
     
@@ -115,10 +117,12 @@ Maki.prototype.serve = function( services ) {
 
     self.services[ name ].init();
     self.services[ name ].attach( self );
-    self.services[ name ].start();
-  });
+    self.services[ name ].start( complete );
 
-  self.served = true;
+  }, function(err, results) {
+    self.served = true;
+    self.emit('ready');
+  });
 
   return self;
 }
@@ -133,7 +137,7 @@ Maki.prototype.start = function( done ) {
   self.datastore.connect(function() {
     self.queue = new self.Queue( self.config );
 
-    if (!self.served) self.serve( Object.keys( self._services ) );
+    if (!self.served) return self.serve( Object.keys( self._services ) , done );
 
     done();
   });

--- a/lib/Maki.js
+++ b/lib/Maki.js
@@ -147,8 +147,12 @@ Maki.prototype.start = function( done ) {
 Maki.prototype.destroy = function( done ) {
   var self = this;
   if (!done) var done = new Function();
-
-  self.datastore.disconnect( done );
+  
+  async.each( self.services , function( service , complete ) {
+    service.destroy( complete );
+  }, function(err) {
+    self.datastore.disconnect( done );
+  });
 
 }
 

--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -749,7 +749,7 @@ HTTP.prototype.start = function( started ) {
 
       self.address = address;
 
-      self.maki.spdyd.listen( sslPort , function() {
+      self.maki.serverSPDY = self.maki.spdyd.listen( sslPort , function() {
         var address = self.maki.spdyd.address();
         if (!self.maki.supress) console.log('[SERVICE]'.bold.green , '[HTTP]'.bold , 'listening'.green, 'for', '[https,spdy]'.bold, 'on' , 'https://' + address.address + ':' + address.port   );
         return started();
@@ -760,6 +760,11 @@ HTTP.prototype.start = function( started ) {
   });
 
 
+};
+
+HTTP.prototype.destroy = function( cb ) {
+  this.maki.server.stop();
+  this.maki.serverSPDY.stop();
 };
 
 module.exports = HTTP;

--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -732,7 +732,7 @@ HTTP.prototype.start = function( started ) {
       self.maki.socks.markAndSweep();
     }, self.maki.config.sockets.timeout );
 
-    self.maki.httpd.listen( self.maki.config.services.http.port , function() {
+    self.maki.server = self.maki.httpd.listen( self.maki.config.services.http.port , function() {
       var address = self.maki.httpd.address();
       self.maki.config.services.http.port = address.port;
 

--- a/lib/Service/index.js
+++ b/lib/Service/index.js
@@ -22,4 +22,9 @@ Service.prototype.attach = function( maki ) {
   return self;
 };
 
+Service.prototype.destroy = function( cb ) {
+  if (!cb) var cb = new Function();
+  return cb();
+};
+
 module.exports = Service;

--- a/test/Maki.integration.js
+++ b/test/Maki.integration.js
@@ -56,11 +56,8 @@ function getRandomInt(min, max) {
 
 before(function(ready) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-  maki.start(function() {
-    setTimeout(function() {
-      ready();
-    }, 250);
-  });
+  maki.start();
+  maki.on('ready', ready );
 });
 
 describe('Maki', function() {


### PR DESCRIPTION
This turns Maki into a proper event emitter, including a `ready` event fired when all services come online.

It also increases the robustness of the `destroy()` method.
