### PR TITLE
Found that get() had a missing pipeline.  Derrrrp.

### DIFF
--- a/lib/Resource/index.js
+++ b/lib/Resource/index.js
@@ -373,15 +373,55 @@ Resource.prototype.query = function( q , opts , complete ) {
 }
 
 // get a SINGLE instance of this resource, based on req.param('id')
-Resource.prototype.get = function( q , complete ) {
+Resource.prototype.get = function( q , opts , complete ) {
+  if (opts instanceof Function) {
+    complete = opts;
+    opts = {};
+  }
   var self = this;
   var Model = self.Model;
 
-  if (!complete) var complete = new Function();
-  Model.findOne( q ).exec(function(err, doc) {
+  async.waterfall([
+    executePreFunctions,
+    executeMethod,
+    executePostFunctions
+  ], function(err, instances) {
     if (err) return complete(err);
-    return complete( err , doc );
+    return complete( err , instances );
   });
+  
+  function executeMethod( q , done ) {
+    var query = Model.findOne( q ).sort('-_id');
+    if (opts.populate) {
+      query.populate( opts.populate );
+    }
+    
+    query.exec(function(err, doc) {
+      if (err) return complete(err);
+      return done( err , doc );
+    });
+  }
+  
+  function executePreFunctions( done ) {
+    async.series( self.middlewares['pre']['get'].map(function(x) {
+      return function( next ) {
+        // NOTE: edited from `create`! 'doc' changed to {}
+        x.apply( {} , [ next , complete ] );
+      };
+    }), function(err, results) {
+      // NOTE: edited from `create`! 'doc' changed to null
+      done( null , q );
+    } );
+  }
+  function executePostFunctions( doc , done ) {
+    async.series( self.middlewares['post']['get'].map(function(x) {
+      return function( done ) {
+        x.apply( doc , [ done ] );
+      };
+    }), function(err, results) {
+      return done( null , doc );
+    });
+  }
 
 }
 


### PR DESCRIPTION
Thanks to @unusualbob and @unChaz, we found a bug in the pipeline
that was meant to apply to the get() method for resources.  Oops.
