### PR TITLE
Allow path exclusion in population.

### DIFF
--- a/lib/Resource/index.js
+++ b/lib/Resource/index.js
@@ -392,8 +392,19 @@ Resource.prototype.get = function( q , opts , complete ) {
   
   function executeMethod( q , done ) {
     var query = Model.findOne( q ).sort('-_id');
-    if (opts.populate) {
-      query.populate( opts.populate );
+
+    if (opts.populate instanceof String) {
+      query.populate( opts.populate.path );
+    }
+    
+    if (opts.populate instanceof Array) {
+      opts.populate.forEach(function(field) {
+        if (field.fields) {
+          query.populate( field.path , field.fields );
+        } else {
+          query.populate( field.path );
+        }
+      });
     }
     
     query.exec(function(err, doc) {

--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -505,8 +505,14 @@ HTTP.prototype.attach = function( maki ) {
       
       if (attribute.populate && attribute.populate instanceof Array) {
         attribute.populate.forEach(function(method) {
-          if (!methodPopulationMap[ method ]) methodPopulationMap[ method ] = [];
-          methodPopulationMap[ method ].push( prop );
+          if (method.method && method.fields) {
+            if (!methodPopulationMap[ method.method ]) methodPopulationMap[ method.method ] = [];
+            method.path = prop;
+            methodPopulationMap[ method.method ].push( method );
+          } else {
+            if (!methodPopulationMap[ method ]) methodPopulationMap[ method ] = [];
+            methodPopulationMap[ method ].push({ path: prop , fields: undefined });
+          }
         });
       }
     }


### PR DESCRIPTION
This adds the fabled object format for `populate` fields.
