### PR TITLE
Client Scripts from Plugins

### DIFF
--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -21,6 +21,7 @@ var HTTP = function() {
   this._post = {};
   this._plugins = [];
   this._scripts = [];
+  this._workers = [];
 };
 
 require('util').inherits( HTTP , Service );
@@ -288,6 +289,7 @@ HTTP.prototype.attach = function( maki ) {
     if (plugin.setup) plugin.setup( maki );
     if (plugin.middleware) maki.app.use( plugin.middleware );
     if (plugin.client) self._scripts.push( plugin.client );
+    if (plugin.worker) self._workers.push( plugin.worker );
   });
 
   maki.app.use(function(req, res, next) {
@@ -768,6 +770,15 @@ HTTP.prototype.start = function( started ) {
   var bundle = fs.createWriteStream(bundlePath);
   bundle.on('open', function() {
     browserify.bundle().pipe(bundle);
+  });
+
+  // TODO: build an extensible service worker platform; events, triggers, etc.
+  self._workers.forEach(function(w) {
+    var workerPath = __dirname + '/../../public/service.js'; // sadly at root :(
+    var worker = fs.createWriteStream(workerPath);
+    worker.on('open', function() {
+      fs.createReadStream(w).pipe(worker);
+    });
   });
 
 

--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -3,6 +3,7 @@ var Service = require('./index');
 var WebSocketServer = require('maki-service-websockets');
 var express = require('express');
 
+var fs = require('fs');
 var pem = require('pem');
 var async = require('async');
 var _ = require('lodash');
@@ -11,12 +12,15 @@ var streamifier = require('streamifier');
 var Torrent = require('node-torrent-stream');
 var ObjectID = require('mongoose').Types.ObjectId;
 
+var Bundler = require('browserify');
+
 var HTTP = function() {
   this.maki = null;
   this.name = 'http';
   this._pre = {};
   this._post = {};
   this._plugins = [];
+  this._scripts = [];
 };
 
 require('util').inherits( HTTP , Service );
@@ -279,8 +283,11 @@ HTTP.prototype.attach = function( maki ) {
   maki.app.locals[ 'services' ]  = maki.services;
 
   self._plugins.forEach(function(plugin) {
+    if (self.debug) console.log('iterating plugin:', plugin);
+
     if (plugin.setup) plugin.setup( maki );
     if (plugin.middleware) maki.app.use( plugin.middleware );
+    if (plugin.client) self._scripts.push( plugin.client );
   });
 
   maki.app.use(function(req, res, next) {
@@ -751,6 +758,18 @@ HTTP.prototype.start = function( started ) {
   var self = this;
 
   if (!started) var started = new Function();
+
+  var browserify = new Bundler();
+  self._scripts.forEach(function(s) {
+    browserify.add(s);
+  });
+
+  var bundlePath = __dirname + '/../../public/js/bundle.js';
+  var bundle = fs.createWriteStream(bundlePath);
+  bundle.on('open', function() {
+    browserify.bundle().pipe(bundle);
+  });
+
 
   // TODO: spdy/https should be the default.  Make it so, with optional http.
   // TODO: allow configurable certificate, supplied by config

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "async": "~0.7.0",
     "body-parser": "~1.2.2",
+    "browserify": "^11.0.1",
     "coalescent": "^0.5.0-alpha.3",
     "colors": "^1.0.3",
     "connect-busboy": "0.0.2",


### PR DESCRIPTION
This now allows for paths to be specified for inclusion in the clientside `bundle.js` from within plugins, via the following:

``` js
somePlugin.extends = {
    services: {
      http: {
        client: 'someJavascriptPath.js'
      }
    }
};
```
