### PR TITLE
Bootstrap New Projects

### DIFF
--- a/data/resource-list.jaml
+++ b/data/resource-list.jaml
@@ -1,0 +1,10 @@
+extends layouts/default
+
+block content
+  h2 List of {{resource.plural}}
+
+  each {{resource.names.get}} in {{resource.names.query}}
+    a.ui.card.fluid.link(href="/{{resource.names.query}}/#{{{resource.names.get}}._id}")
+      .content
+        h3.header {{resource.name}}: #{{{resource.names.get}}._id}
+        pre #{{{resource.names.get}}}

--- a/data/resource-view.jaml
+++ b/data/resource-view.jaml
@@ -1,0 +1,9 @@
+extends layouts/default
+
+block content
+  h2 Single {{resource.name}}
+
+  .ui.card.fluid
+    .content
+      h3.header {{resource.name}}: #{{{resource.names.get}}._id}
+      pre #{{{resource.names.get}}}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,6 +11,20 @@ it makes heuristics in various places much easier.  `Person` in this case will
 become `/people` (automatically!) as a collection, and it contains a list of
 `person` items.  That's pretty neat!
 
+### Bootstrapping
+Applications built with Maki provide sane defaults, but can be completely customized.  The directory structure for customization can be automatically created for you, by simply calling `bootstrap` _after_ your Resources have been defined:
+
+```javascript
+maki.define('Person', {
+  attributes: ...
+});
+
+maki.bootstrap();
+```
+This is a chainable method, so `maki.bootstrap().start();` will also work.
+
+### Attributes
+
 Defining a Resource in Maki has but one requirement, the list of `attributes` it
 provides.  You can think of this like a Type Definition in a more strongly-typed
 language:
@@ -21,7 +35,7 @@ maki.define('Person', {
 });
 ```
 
-The attributes associated with a Resource _will_ enforce type, too!  The names 
+The attributes associated with a Resource _will_ enforce type, too!  The names
 are used to control parameters when interacting with the resource, so choose
 them wisely.
 
@@ -108,7 +122,7 @@ unique to these types.
 
 ##### File
 The `'File'` type will create a specially aliased attribute that exposes a raw
-file stream.  Files can be uploaded to fields labeled `type: 'File'`, and are 
+file stream.  Files can be uploaded to fields labeled `type: 'File'`, and are
 downloadable via a special `Files` resource (exposed over HTTP at `/files`).
 
 These field types are rendered in HTML as file upload input elements, and offer
@@ -144,10 +158,10 @@ var Person = maki.define('Person', {
 
 Person.pre('create', function(done) {
   var person = this;
-  
+
   // trim any whitespace from the individual's name.
   person.name = person.name.trim();
-  
+
   done();
 });
 
@@ -194,7 +208,7 @@ ws.onmessage = function( data ) {
 
 These WebSockets speak JSON-RPC, and specifically expose these methods:
 - `ping`, which should be responded to with a "pong" result.
-- `patch`, which provides an array of operations to execute on a resource (via 
+- `patch`, which provides an array of operations to execute on a resource (via
   [the JSON-PATCH specification][json patch])
 - `subscribe` will expect a `channel` parameter that matches the "collection"
 name of the expected resource (see below).
@@ -285,7 +299,7 @@ will likely include the ability to pass a function in this field.
 
 #### Requirements
 Any resource can have additional requirements when requested via a non-
-programmatic endpoint (such as a rendered HTML view).  You can them via the 
+programmatic endpoint (such as a rendered HTML view).  You can them via the
 `requires` property:
 
 ```javascript

--- a/lib/Maki.js
+++ b/lib/Maki.js
@@ -2,6 +2,8 @@
 
 if (process.env.NODE_ENV === 'debug') require('debug-trace')({ always: true });
 
+var fs = require('fs-extra');
+
 var _ = require('lodash');
 var colors = require('colors');
 var util = require('util');
@@ -114,7 +116,7 @@ Maki.prototype.serve = function( services , cb ) {
   async.each( services , function( name , complete ) {
     var Service = self._services[ name ];
     self.services[ name ] = new Service();
-    
+
     if (self.plugins[ name ] && self.plugins[ name ].length) {
       self.plugins[ name ].forEach(function(plugin) {
         self.services[ name ]._plugins.push( plugin );
@@ -141,12 +143,12 @@ Maki.prototype.serve = function( services , cb ) {
   });
 
   return self;
-}
+};
 
 Maki.prototype.start = function( done ) {
   var self = this;
   if (!done) var done = new Function();
-  
+
   self.messenger = new self.Messenger();
 
   self.datastore = new self.Datastore( self.config );
@@ -158,18 +160,74 @@ Maki.prototype.start = function( done ) {
     done();
   });
 
-}
+};
 
 Maki.prototype.destroy = function( done ) {
   var self = this;
   if (!done) var done = new Function();
-  
+
   async.each( self.services , function( service , complete ) {
     service.destroy( complete );
   }, function(err) {
     self.datastore.disconnect( done );
   });
 
-}
+};
+
+Maki.prototype.bootstrap = function(done) {
+  var self = this;
+  var base = process.env.PWD;
+  var maki = __dirname + '/..';
+  var main = [
+    '/views',
+    '/views/layouts',
+    '/views/partials'
+  ];
+
+  main.forEach(function(f) {
+    if (!fs.existsSync(base+f)) fs.mkdirSync(base+f);
+  });
+
+  Object.keys(self.resources).forEach(function(r) {
+    var resource = self.resources[r];
+    var listName = resource.plural.toLowerCase();
+    var viewName = resource.name.toLowerCase();
+    var listView = base+'/views/'+listName+'.jade';
+    var viewView = base+'/views/'+viewName+'.jade';
+
+    var reqs = [
+      '/views/layouts/default.jade',
+      '/views/partials/navbar.jade',
+      '/views/partials/flash.jade'
+    ];
+
+    reqs.forEach(function(r) {
+      if (!fs.existsSync(base+r)) fs.copySync(maki+r, base+r);
+    });
+
+    if (!fs.existsSync(listView)) {
+      var template = fs.readFileSync(maki+'/data/resource-list.jaml')
+        .toString()
+        .replace(/{{resource.name}}/gi, resource.name)
+        .replace(/{{resource.plural}}/gi, resource.plural)
+        .replace(/{{resource.names.query}}/gi, resource.names.query)
+        .replace(/{{resource.names.get}}/gi, resource.names.get);
+      fs.writeFileSync(listView, template);
+    }
+
+    if (!fs.existsSync(viewView)) {
+      var template = fs.readFileSync(maki+'/data/resource-view.jaml')
+        .toString()
+        .replace(/{{resource.name}}/gi, resource.name)
+        .replace(/{{resource.plural}}/gi, resource.plural)
+        .replace(/{{resource.names.query}}/gi, resource.names.query)
+        .replace(/{{resource.names.get}}/gi, resource.names.get);
+      fs.writeFileSync(viewView, template);
+    }
+
+  });
+
+  done();
+};
 
 module.exports = Maki;

--- a/lib/Maki.js
+++ b/lib/Maki.js
@@ -183,6 +183,10 @@ Maki.prototype.bootstrap = function(done) {
     '/views/layouts',
     '/views/partials'
   ];
+  
+  if (!done) {
+    var done = new Function();
+  }
 
   main.forEach(function(f) {
     if (!fs.existsSync(base+f)) fs.mkdirSync(base+f);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "express": "git://github.com/martindale/express#multiple-views",
     "fast-json-patch": "^0.3.6",
     "flashify": "^0.1.2",
+    "fs-extra": "^0.24.0",
     "gridfs-stream": "^0.5.3",
     "jade": "git://github.com/martindale/jade#extends-expressions",
     "jade-browser": "0.0.14",


### PR DESCRIPTION
This adds a new method to the base Maki class, `bootstrap`, that will create the local directory structure necessary to custom modify "views" without much trouble.

To run it, execute `maki.bootstrap()` after defining your resources:

``` js
var Maki = require('maki');
var maki = new Maki();

maki.define('Widget', {
  name: String
});

maki.bootstrap().start();
```
