### PR TITLE
Fix OPTIONS requests

### DIFF
--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -332,11 +332,22 @@ HTTP.prototype.attach = function( maki ) {
       return resource;
     });
 
+    var resourceMap = {};
+    Object.keys(maki.resources).filter(function(r) {
+      var resource = maki.resources[ r ];
+      return !resource.internal || !resource.static;
+    }).forEach(function(name) {
+      var model = maki.resources[name];
+      var resource = _.clone(model, true);
+      delete resource.Schema;
+      resourceMap[name] = resource;
+    });
+
     return res.format({
       html: function() {
         res.render('endpoints', {
           resources: resourceList
-        })
+        });
       },
       json: function() {
         res.send({
@@ -345,8 +356,7 @@ HTTP.prototype.attach = function( maki ) {
               client: maki.config.views.client
             }
           },
-          // TODO: fix circular JSON issue here
-          resources: resourceList
+          resources: resourceMap
         });
       }
     });
@@ -604,7 +614,7 @@ HTTP.prototype.attach = function( maki ) {
       // there is a slight difference in how Resource methods are implemented//
       // specifically, "editing" a resourcing requires 1) a query , and 2)//
       // patches.  Perhaps we can use a "builder" and .apply() here.
-      
+
       if (p === 'query') {
         var executor = function(req, res, next) {
           req.m = p;
@@ -694,7 +704,7 @@ HTTP.prototype.attach = function( maki ) {
             });
           });
         }
-        
+
         maki.app['put']( regex + '/:id' , function(req, res, next) {
           req.m = p;
           if (resource.source) return res.status( 405 ).provide( r );
@@ -707,7 +717,7 @@ HTTP.prototype.attach = function( maki ) {
             return res.provide( r , instance );
           });
         });
-        
+
       } else if (p === 'update') {
         var executor = function(req, res, next) {
           req.m = p;
@@ -752,7 +762,7 @@ HTTP.prototype.attach = function( maki ) {
       var stack = [ regex ];
       var pre = [];
       var post = [];
-      
+
       pre.push(function setupMiddleware(req, res, next) {
         req.resource = resource;
         next();


### PR DESCRIPTION
There was a circular reference issue with the JSON results sent to clients requesting the OPTIONS of a Maki application.  This resolves that issue, albeit sub-optimally.

Refactor later.
