### PR TITLE
Disable SPDY startup

### DIFF
--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -1029,10 +1029,10 @@ HTTP.prototype.start = function( started ) {
     //self.maki.config.services.spdy.port = sslPort;
 
     //self.maki.httpd = require('http').createServer( self.maki.app );
-    self.maki.spdyd = require('spdy').createServer({
+    /* self.maki.spdyd = require('spdy').createServer({
       key: keys.serviceKey,
       cert: keys.certificate
-    }, self.maki.app );
+    }, self.maki.app ); */
 
     self.maki.socks.bind( self.maki );
 
@@ -1060,7 +1060,7 @@ HTTP.prototype.start = function( started ) {
 
       self.address = address;
 
-      self.maki.serverSPDY = self.maki.spdyd.listen( sslPort , function() {
+      /*self.maki.serverSPDY = self.maki.spdyd.listen( sslPort , function() {
         var address = self.maki.spdyd.address();
         if (!self.maki.supress) console.log('[SERVICE]'.bold.green , '[HTTP]'.bold , 'listening'.green, 'for', '[https,spdy]'.bold, 'on' , 'https://' + address.address + ':' + address.port   );
 
@@ -1068,7 +1068,7 @@ HTTP.prototype.start = function( started ) {
         self.maki.emit('service:http:started');
 
         return started();
-      });
+      });*/
 
     });
 

--- a/lib/Service/http.js
+++ b/lib/Service/http.js
@@ -1020,12 +1020,12 @@ HTTP.prototype.start = function( started ) {
   // TODO: spdy/https should be the default.  Make it so, with optional http.
   // TODO: allow configurable certificate, supplied by config
   // this will allow for standalone mode, as well as a "backend worker" mode.
-  pem.createCertificate({
+  /* pem.createCertificate({
     days: 90,
     selfSigned: true
-  }, function(err, keys) {
+  }, function(err, keys) { */
 
-    var sslPort = self.maki.config.services.http.port + 443 - 80;
+    //var sslPort = self.maki.config.services.http.port + 443 - 80;
     //self.maki.config.services.spdy.port = sslPort;
 
     //self.maki.httpd = require('http').createServer( self.maki.app );
@@ -1059,6 +1059,10 @@ HTTP.prototype.start = function( started ) {
       if (!self.maki.supress) console.log('[SERVICE]'.bold.green , '[HTTP]'.bold , 'listening'.green, 'for', '[http]      '.bold, 'on ' , 'http://' + address.address + ':' + address.port  );
 
       self.address = address;
+      
+      self.emit('started');
+      self.maki.emit('service:http:started');
+      return started();
 
       /*self.maki.serverSPDY = self.maki.spdyd.listen( sslPort , function() {
         var address = self.maki.spdyd.address();
@@ -1079,7 +1083,7 @@ HTTP.prototype.start = function( started ) {
 
 HTTP.prototype.destroy = function( cb ) {
   this.maki.server.stop();
-  this.maki.serverSPDY.stop();
+  //this.maki.serverSPDY.stop();
 };
 
 module.exports = HTTP;


### PR DESCRIPTION
We're deprecating SPDY and will replace it with HTTP2 if possible for this release.  Otherwise scratch.